### PR TITLE
Fix some remainder/truncation duals

### DIFF
--- a/src/forward_autodiff.rs
+++ b/src/forward_autodiff.rs
@@ -463,14 +463,14 @@ where
     }
 }
 
-impl<V: Rem<f64>, D: Rem<f64>> Rem<f64> for F<V, D> {
+impl<V: Rem<f64>, D: Rem<f64, Output = D>> Rem<f64> for F<V, D> {
     type Output = F<V::Output, D::Output>;
     #[inline]
     fn rem(self, rhs: f64) -> Self::Output {
         // This is an approximation. There are places where the derivative doesn't exist.
         F {
             x: self.x % rhs, // x % y = x - [x/|y|]*|y|
-            dx: self.dx % rhs,
+            dx: self.dx,
         }
     }
 }
@@ -509,7 +509,6 @@ impl<V: RemAssign<f64>, D: RemAssign<f64>> RemAssign<f64> for F<V, D> {
     #[inline]
     fn rem_assign(&mut self, rhs: f64) {
         self.x %= rhs;
-        self.dx %= rhs;
     }
 }
 
@@ -517,7 +516,6 @@ impl<V: RemAssign<f32>, D: RemAssign<f32>> RemAssign<f32> for F<V, D> {
     #[inline]
     fn rem_assign(&mut self, rhs: f32) {
         self.x %= rhs;
-        self.dx %= rhs;
     }
 }
 
@@ -915,28 +913,28 @@ where
     fn floor(self) -> F<V, D> {
         F {
             x: self.x.floor(),
-            dx: self.dx,
+            dx: D::zero(),
         }
     }
     #[inline]
     fn ceil(self) -> F<V, D> {
         F {
             x: self.x.ceil(),
-            dx: self.dx,
+            dx: D::zero(),
         }
     }
     #[inline]
     fn round(self) -> F<V, D> {
         F {
             x: self.x.round(),
-            dx: self.dx,
+            dx: D::zero(),
         }
     }
     #[inline]
     fn trunc(self) -> F<V, D> {
         F {
             x: self.x.trunc(),
-            dx: self.dx,
+            dx: D::zero(),
         }
     }
     #[inline]


### PR DESCRIPTION
I could be wrong about these, but:
- Removed a few places were the `%` operator was applied to the `dx` component (that should basically never happen, afaict)
- Set `dx` to 0 in a few cases (`floor`, `ceil`, `round`, etc). These functions are flat everywhere they're differentiable, epsilon perturbations will always leave the value unchanged, so the `dx` component should be wiped out by them, unless I'm mistaken.

I considered adding tests but simple tests would just repeat my assumptions about how the math should work (e.g. asserting `dx == 0` in some cases). It would be nice to add tests that perturb values by `EPSILON`, and verify that the empirical and theoretical gradients match. I'm open to trying that out, but maybe as a follow-on PR, as ≈all of the operations warrant that, not just the ones I've touched here.