### PR TITLE
Update nalgebra and simba version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,9 +18,9 @@ travis-ci = { repository = "elrnv/autodiff", branch = "master" }
 [dependencies]
 num-traits = "0.2"
 approx = { version = "0.5", optional = true }
-nalgebra = { version = "0.32", optional = true }
+nalgebra = { version = "0.33", optional = true }
 bytemuck = { version = "1", optional = true }
-simba = { version = "0.8", optional = true }
+simba = { version = "0.9", optional = true }
 cgmath = { version = "0.18", optional = true }
 
 [dev-dependencies]

--- a/src/forward_autodiff.rs
+++ b/src/forward_autodiff.rs
@@ -89,35 +89,6 @@ impl<V: PartialOrd, D, U> PartialOrd<F<V, U>> for F<V, D> {
     }
 }
 
-/// Compare the values and derivatives of two dual numbers for equality.
-trait DualEq {
-    fn dual_eq(&self, rhs: &Self) -> bool;
-}
-
-impl DualEq for f32 {
-    /// Compare two single precision floats for equality.
-    #[inline]
-    fn dual_eq(&self, rhs: &f32) -> bool {
-        self == rhs
-    }
-}
-
-impl DualEq for f64 {
-    /// Compare two double precision floats for equality.
-    #[inline]
-    fn dual_eq(&self, rhs: &f64) -> bool {
-        self == rhs
-    }
-}
-
-impl<V: PartialEq, D: DualEq> DualEq for F<V, D> {
-    /// Compare two `F`s in full, including the derivative part.
-    #[inline]
-    fn dual_eq(&self, rhs: &F<V, D>) -> bool {
-        self.x == rhs.x && self.dx.dual_eq(&rhs.dx)
-    }
-}
-
 impl<V: ToPrimitive, D> Into<f64> for F<V, D> {
     /// Converts the dual number into an `f64`.
     ///
@@ -1458,6 +1429,35 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Compare the values and derivatives of two dual numbers for equality.
+    trait DualEq {
+        fn dual_eq(&self, rhs: &Self) -> bool;
+    }
+
+    impl DualEq for f32 {
+        /// Compare two single precision floats for equality.
+        #[inline]
+        fn dual_eq(&self, rhs: &f32) -> bool {
+            self == rhs
+        }
+    }
+
+    impl DualEq for f64 {
+        /// Compare two double precision floats for equality.
+        #[inline]
+        fn dual_eq(&self, rhs: &f64) -> bool {
+            self == rhs
+        }
+    }
+
+    impl<V: PartialEq, D: DualEq> DualEq for F<V, D> {
+        /// Compare two `F`s in full, including the derivative part.
+        #[inline]
+        fn dual_eq(&self, rhs: &F<V, D>) -> bool {
+            self.x == rhs.x && self.dx.dual_eq(&rhs.dx)
+        }
+    }
 
     /// Convenience macro for comparing `F`s in full.
     macro_rules! assert_dual_eq {

--- a/src/nalgebra.rs
+++ b/src/nalgebra.rs
@@ -543,22 +543,6 @@ where
 {
 }
 
-//impl<V, D, B> Field for F<V, D>
-//where
-//    B: SimdBool,
-//    V: Clone + Field<SimdBool = B> + RemAssign + Div<Output = V> + Float,
-//    D: Clone
-//        + Field<SimdBool = B>
-//        + Mul<V, Output = D>
-//        + SubAssign
-//        + std::ops::DivAssign<V>
-//        + std::ops::MulAssign<V>
-//        + std::fmt::Debug
-//        + Div<V>
-//        + Div<V, Output = D>,
-//{
-//}
-
 impl<V, D, B> SimdValue for F<V, D>
 where
     B: SimdBool,
@@ -568,10 +552,7 @@ where
     type Element = F<V::Element, D::Element>;
     type SimdBool = B;
 
-    #[inline(always)]
-    fn lanes() -> usize {
-        V::lanes()
-    }
+    const LANES: usize = V::LANES;
 
     #[inline(always)]
     fn splat(val: Self::Element) -> Self {


### PR DESCRIPTION
Hi @elrnv,
thanks for providing and maintaining this library!

This PR updates the `nalgebra` version to `0.33` which now reqires `simba`in version `0.9` ( see [Changelog](https://github.com/dimforge/nalgebra/blob/main/CHANGELOG.md#0330-23-june-2024)).

`simba` has applied som API changes in `0.9`:
*  `SimdValue::lanes()` has been changed to `SimValue::LANES`
* `ComplexField` now also requires that `SupersetOf<f32>` is implemented (additionally to `Superset<f64>`)

Se also the [Changelog](https://github.com/dimforge/simba/blob/dfdfba3/CHANGELOG#L1-L12).

I updated the trait implementations and added some test for `SupersetOf`. I also did some tidy up work like removing outcommented code in `nalgebra.rs` and moving a test only trait and its implementation into the test scope.